### PR TITLE
Correct local temperature calibration min and max value on Sonoff TRVZB

### DIFF
--- a/zha/application/platforms/number/__init__.py
+++ b/zha/application/platforms/number/__init__.py
@@ -862,8 +862,8 @@ class ThermostatLocalTempCalibration(NumberConfigurationEntity):
 class SonoffThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
     """Local temperature calibration for the Sonoff TRVZB."""
 
-    _attr_native_min_value: float = -7
-    _attr_native_max_value: float = 7
+    _attr_native_min_value: float = -12.8
+    _attr_native_max_value: float = 12.7
     _attr_native_step: float = 0.2
 
 


### PR DESCRIPTION
From https://github.com/Koenkk/zigbee-herdsman-converters/pull/8214 via https://github.com/zigpy/zha-device-handlers/pull/3358#issuecomment-2485862165.